### PR TITLE
Fix DatetimePicker crash

### DIFF
--- a/src/imports/controls-private/DateSelector.qml
+++ b/src/imports/controls-private/DateSelector.qml
@@ -166,14 +166,14 @@ FluidTemplates.DateSelector {
                             height: parent.height
                             horizontalAlignment: Text.AlignHCenter
                             verticalAlignment: Text.AlignVCenter
-                            color: isEqual(selectedDate) ? "white" : (isEqual(new Date()) ? control.Material.accent : control.Material.primaryTextColor)
+                            color: isEqual(selectedDate) ? control.Material.theme === Material.Dark ? "black" : "white" : (isEqual(new Date()) ? control.Material.accent : control.Material.primaryTextColor)
                             opacity: model.month === grid.month ? 1 : 0
                         }
 
                         MouseArea {
                             anchors.fill: parent
                             enabled: model.month === grid.month
-                            onClicked: control.selectedDate = model.date
+                            onClicked: control.selectedDate = new Date(model.year, model.month, model.day)
                         }
 
                         function isEqual(date) {

--- a/src/imports/controls/DatePicker.qml
+++ b/src/imports/controls/DatePicker.qml
@@ -102,7 +102,7 @@ FluidTemplates.DatePicker {
                     date.setDate(selectedDate.getDate());
                     date.setMonth(selectedDate.getMonth());
                     date.setFullYear(selectedDate.getFullYear());
-                    picker.selectedDate = new Date(date.getTime());
+                    selectedDate = new Date(date.getTime());
                     yearSelector.selectedYear = selectedDate.getFullYear();
                 }
             }

--- a/src/imports/controls/DateTimePicker.qml
+++ b/src/imports/controls/DateTimePicker.qml
@@ -230,7 +230,7 @@ FluidTemplates.DateTimePicker {
             locale: picker.locale
             visible: picker.mode === FluidTemplates.DateTimePicker.Month
             onSelectedDateChanged: {
-                if (picker.selectedDateTime !== selectedDate) {
+                if (picker.selectedDateTime.getDate() !== selectedDate.getDate()) {
                     var date = new Date(picker.selectedDateTime.getTime());
                     date.setDate(selectedDate.getDate());
                     date.setMonth(selectedDate.getMonth());

--- a/src/imports/templates/datepicker.cpp
+++ b/src/imports/templates/datepicker.cpp
@@ -88,8 +88,8 @@
 
 DatePicker::DatePicker(QQuickItem *parent)
     : Picker(parent)
-    , m_from(1, 1, 1)
-    , m_to(275759, 9, 25)
+    , m_from(QDate(1, 1, 1))
+    , m_to(QDate(275759, 9, 25))
     , m_selectedDate(QDate::currentDate())
 {
 }
@@ -162,14 +162,14 @@ void DatePicker::setWeekNumberVisible(bool value)
 
     This property holds the start date.
 */
-QDate DatePicker::from() const
+QDateTime DatePicker::from() const
 {
     return m_from;
 }
 
-void DatePicker::setFrom(const QDate &date)
+void DatePicker::setFrom(const QDateTime &date)
 {
-    if (m_from == date)
+    if (m_from.date() == date.date())
         return;
 
     m_from = date;
@@ -178,7 +178,7 @@ void DatePicker::setFrom(const QDate &date)
 
 void DatePicker::resetFrom()
 {
-    setFrom(QDate(1, 1, 1));
+    setFrom(QDateTime(QDate(1, 1, 1)));
 }
 
 /*!
@@ -186,14 +186,14 @@ void DatePicker::resetFrom()
 
     This property holds the end date.
 */
-QDate DatePicker::to() const
+QDateTime DatePicker::to() const
 {
     return m_to;
 }
 
-void DatePicker::setTo(const QDate &date)
+void DatePicker::setTo(const QDateTime &date)
 {
-    if (m_to == date)
+    if (m_to.date() == date.date())
         return;
 
     m_to = date;
@@ -202,7 +202,7 @@ void DatePicker::setTo(const QDate &date)
 
 void DatePicker::resetTo()
 {
-    setTo(QDate(275759, 9, 25));
+    setTo(QDateTime(QDate(275759, 9, 25)));
 }
 
 /*!
@@ -211,14 +211,14 @@ void DatePicker::resetTo()
     This property holds the date that has been selected by the user.
     The default value is the current date.
 */
-QDate DatePicker::selectedDate() const
+QDateTime DatePicker::selectedDate() const
 {
-    return m_selectedDate;
+    return QDateTime(m_selectedDate.date());
 }
 
-void DatePicker::setSelectedDate(const QDate &date)
+void DatePicker::setSelectedDate(const QDateTime &date)
 {
-    if (m_selectedDate == date)
+    if (m_selectedDate.date() == date.date())
         return;
 
     m_selectedDate = date;

--- a/src/imports/templates/datepicker.h
+++ b/src/imports/templates/datepicker.h
@@ -25,9 +25,9 @@ class DatePicker : public Picker
     Q_PROPERTY(Mode mode READ mode WRITE setMode NOTIFY modeChanged FINAL)
     Q_PROPERTY(bool dayOfWeekRowVisible READ dayOfWeekRowVisible WRITE setDayOfWeekRowVisible NOTIFY dayOfWeekRowVisibleChanged FINAL)
     Q_PROPERTY(bool weekNumberVisible READ weekNumberVisible WRITE setWeekNumberVisible NOTIFY weekNumberVisibleChanged FINAL)
-    Q_PROPERTY(QDate from READ from WRITE setFrom RESET resetFrom NOTIFY fromChanged FINAL)
-    Q_PROPERTY(QDate to READ to WRITE setTo RESET resetTo NOTIFY toChanged FINAL)
-    Q_PROPERTY(QDate selectedDate READ selectedDate WRITE setSelectedDate NOTIFY selectedDateChanged FINAL)
+    Q_PROPERTY(QDateTime from READ from WRITE setFrom RESET resetFrom NOTIFY fromChanged FINAL)
+    Q_PROPERTY(QDateTime to READ to WRITE setTo RESET resetTo NOTIFY toChanged FINAL)
+    Q_PROPERTY(QDateTime selectedDate READ selectedDate WRITE setSelectedDate NOTIFY selectedDateChanged FINAL)
 public:
     enum Mode {
         Year,
@@ -46,16 +46,16 @@ public:
     bool weekNumberVisible() const;
     void setWeekNumberVisible(bool value);
 
-    QDate from() const;
-    void setFrom(const QDate &date);
+    QDateTime from() const;
+    void setFrom(const QDateTime &date);
     void resetFrom();
 
-    QDate to() const;
-    void setTo(const QDate &date);
+    QDateTime to() const;
+    void setTo(const QDateTime &date);
     void resetTo();
 
-    QDate selectedDate() const;
-    void setSelectedDate(const QDate &date);
+    QDateTime selectedDate() const;
+    void setSelectedDate(const QDateTime &date);
 
 Q_SIGNALS:
     void modeChanged();
@@ -69,9 +69,9 @@ private:
     Mode m_mode = Month;
     bool m_dayOfWeekRowVisible = true;
     bool m_weekNumberVisible = true;
-    QDate m_from;
-    QDate m_to;
-    QDate m_selectedDate;
+    QDateTime m_from;
+    QDateTime m_to;
+    QDateTime m_selectedDate;
 };
 
 #endif // DATEPICKER_H

--- a/src/imports/templates/dateselector.cpp
+++ b/src/imports/templates/dateselector.cpp
@@ -17,8 +17,8 @@
 DateSelector::DateSelector(QQuickItem *parent)
     : QQuickItem(parent)
     , m_contentItem(new QQuickItem(this))
-    , m_from(1, 1, 1)
-    , m_to(275759, 9, 25)
+    , m_from(QDate(1, 1, 1))
+    , m_to(QDate(275759, 9, 25))
     , m_selectedDate(QDate::currentDate())
 {
     m_contentItem->setParentItem(this);
@@ -122,12 +122,12 @@ void DateSelector::resetWeekNumberVisible()
     setWeekNumberVisible(true);
 }
 
-QDate DateSelector::from() const
+QDateTime DateSelector::from() const
 {
     return m_from;
 }
 
-void DateSelector::setFrom(const QDate &date)
+void DateSelector::setFrom(const QDateTime &date)
 {
     if (m_from == date)
         return;
@@ -138,17 +138,17 @@ void DateSelector::setFrom(const QDate &date)
 
 void DateSelector::resetFrom()
 {
-    setFrom(QDate(1, 1, 1));
+    setFrom(QDateTime(QDate(1, 1, 1)));
 }
 
-QDate DateSelector::to() const
+QDateTime DateSelector::to() const
 {
-    return m_to;
+    return QDateTime(m_to.date());
 }
 
-void DateSelector::setTo(const QDate &date)
+void DateSelector::setTo(const QDateTime &date)
 {
-    if (m_to == date)
+    if (m_to.date() == date.date())
         return;
 
     m_to = date;
@@ -157,17 +157,17 @@ void DateSelector::setTo(const QDate &date)
 
 void DateSelector::resetTo()
 {
-    setTo(QDate(275759, 9, 25));
+    setTo(QDateTime(QDate(275759, 9, 25)));
 }
 
-QDate DateSelector::selectedDate() const
+QDateTime DateSelector::selectedDate() const
 {
-    return m_selectedDate;
+    return QDateTime(m_selectedDate.date());
 }
 
-void DateSelector::setSelectedDate(const QDate &date)
+void DateSelector::setSelectedDate(const QDateTime &date)
 {
-    if (m_selectedDate == date)
+    if (m_selectedDate.date() == date.date())
         return;
 
     m_selectedDate = date;

--- a/src/imports/templates/dateselector.h
+++ b/src/imports/templates/dateselector.h
@@ -27,9 +27,9 @@ class DateSelector : public QQuickItem
     Q_PROPERTY(QQuickItem *calendar READ calendar WRITE setCalendar NOTIFY calendarChanged FINAL)
     Q_PROPERTY(bool dayOfWeekRowVisible READ dayOfWeekRowVisible WRITE setDayOfWeekRowVisible RESET resetDayOfWeekRowVisible NOTIFY dayOfWeekRowVisibleChanged FINAL)
     Q_PROPERTY(bool weekNumberVisible READ weekNumberVisible WRITE setWeekNumberVisible RESET resetWeekNumberVisible NOTIFY weekNumberVisibleChanged FINAL)
-    Q_PROPERTY(QDate from READ from WRITE setFrom RESET resetFrom NOTIFY fromChanged FINAL)
-    Q_PROPERTY(QDate to READ to WRITE setTo RESET resetTo NOTIFY toChanged FINAL)
-    Q_PROPERTY(QDate selectedDate READ selectedDate WRITE setSelectedDate NOTIFY selectedDateChanged FINAL)
+    Q_PROPERTY(QDateTime from READ from WRITE setFrom RESET resetFrom NOTIFY fromChanged FINAL)
+    Q_PROPERTY(QDateTime to READ to WRITE setTo RESET resetTo NOTIFY toChanged FINAL)
+    Q_PROPERTY(QDateTime selectedDate READ selectedDate WRITE setSelectedDate NOTIFY selectedDateChanged FINAL)
     Q_DISABLE_COPY(DateSelector)
 public:
     explicit DateSelector(QQuickItem *parent = nullptr);
@@ -53,16 +53,16 @@ public:
     void setWeekNumberVisible(bool value);
     void resetWeekNumberVisible();
 
-    QDate from() const;
-    void setFrom(const QDate &date);
+    QDateTime from() const;
+    void setFrom(const QDateTime &date);
     void resetFrom();
 
-    QDate to() const;
-    void setTo(const QDate &date);
+    QDateTime to() const;
+    void setTo(const QDateTime &date);
     void resetTo();
 
-    QDate selectedDate() const;
-    void setSelectedDate(const QDate &date);
+    QDateTime selectedDate() const;
+    void setSelectedDate(const QDateTime &date);
 
 Q_SIGNALS:
     void localeChanged();
@@ -81,9 +81,9 @@ private:
     QQuickItem *m_calendar = nullptr;
     bool m_dayOfWeekRowVisible = true;
     bool m_weekNumberVisible = true;
-    QDate m_from;
-    QDate m_to;
-    QDate m_selectedDate;
+    QDateTime m_from;
+    QDateTime m_to;
+    QDateTime m_selectedDate;
 
 private Q_SLOTS:
     void updateLayout();

--- a/src/imports/templates/datetimepicker.cpp
+++ b/src/imports/templates/datetimepicker.cpp
@@ -88,8 +88,8 @@
 
 DateTimePicker::DateTimePicker(QQuickItem *parent)
     : Picker(parent)
-    , m_from(1, 1, 1)
-    , m_to(275759, 9, 25)
+    , m_from(QDate(1, 1, 1))
+    , m_to(QDate(275759, 9, 25))
     , m_selectedDateTime(QDateTime::currentDateTime())
 {
 }
@@ -184,12 +184,12 @@ void DateTimePicker::setPrefer24Hour(bool value)
 
     This property holds the start date.
 */
-QDate DateTimePicker::from() const
+QDateTime DateTimePicker::from() const
 {
     return m_from;
 }
 
-void DateTimePicker::setFrom(const QDate &date)
+void DateTimePicker::setFrom(const QDateTime &date)
 {
     if (m_from == date)
         return;
@@ -200,7 +200,7 @@ void DateTimePicker::setFrom(const QDate &date)
 
 void DateTimePicker::resetFrom()
 {
-    setFrom(QDate(1, 1, 1));
+    setFrom(QDateTime(QDate(1, 1, 1)));
 }
 
 /*!
@@ -208,12 +208,12 @@ void DateTimePicker::resetFrom()
 
     This property holds the end date.
 */
-QDate DateTimePicker::to() const
+QDateTime DateTimePicker::to() const
 {
     return m_to;
 }
 
-void DateTimePicker::setTo(const QDate &date)
+void DateTimePicker::setTo(const QDateTime &date)
 {
     if (m_to == date)
         return;
@@ -224,7 +224,7 @@ void DateTimePicker::setTo(const QDate &date)
 
 void DateTimePicker::resetTo()
 {
-    setTo(QDate(275759, 9, 25));
+    setTo(QDateTime(QDate(275759, 9, 25)));
 }
 
 /*!

--- a/src/imports/templates/datetimepicker.h
+++ b/src/imports/templates/datetimepicker.h
@@ -26,8 +26,8 @@ class DateTimePicker : public Picker
     Q_PROPERTY(bool dayOfWeekRowVisible READ dayOfWeekRowVisible WRITE setDayOfWeekRowVisible NOTIFY dayOfWeekRowVisibleChanged FINAL)
     Q_PROPERTY(bool weekNumberVisible READ weekNumberVisible WRITE setWeekNumberVisible NOTIFY weekNumberVisibleChanged FINAL)
     Q_PROPERTY(bool prefer24Hour READ prefer24Hour WRITE setPrefer24Hour NOTIFY prefer24HourChanged FINAL)
-    Q_PROPERTY(QDate from READ from WRITE setFrom RESET resetFrom NOTIFY fromChanged FINAL)
-    Q_PROPERTY(QDate to READ to WRITE setTo RESET resetTo NOTIFY toChanged FINAL)
+    Q_PROPERTY(QDateTime from READ from WRITE setFrom RESET resetFrom NOTIFY fromChanged FINAL)
+    Q_PROPERTY(QDateTime to READ to WRITE setTo RESET resetTo NOTIFY toChanged FINAL)
     Q_PROPERTY(QDateTime selectedDateTime READ selectedDateTime WRITE setSelectedDateTime NOTIFY selectedDateTimeChanged FINAL)
 public:
     enum Mode {
@@ -53,12 +53,12 @@ public:
     bool prefer24Hour() const;
     void setPrefer24Hour(bool value);
 
-    QDate from() const;
-    void setFrom(const QDate &date);
+    QDateTime from() const;
+    void setFrom(const QDateTime &date);
     void resetFrom();
 
-    QDate to() const;
-    void setTo(const QDate &date);
+    QDateTime to() const;
+    void setTo(const QDateTime &date);
     void resetTo();
 
     QDateTime selectedDateTime() const;
@@ -78,8 +78,8 @@ private:
     bool m_dayOfWeekRowVisible = true;
     bool m_weekNumberVisible = true;
     bool m_prefer24Hour = true;
-    QDate m_from;
-    QDate m_to;
+    QDateTime m_from;
+    QDateTime m_to;
     QDateTime m_selectedDateTime;
 };
 

--- a/src/imports/templates/picker.h
+++ b/src/imports/templates/picker.h
@@ -63,7 +63,7 @@ Q_SIGNALS:
     void headerChanged();
     void selectorChanged();
     void footerChanged();
-    void accepted(const QDate &date);
+    void accepted(const QDateTime &date);
     void rejected();
 
 protected:

--- a/src/imports/templates/yearmodel.cpp
+++ b/src/imports/templates/yearmodel.cpp
@@ -16,33 +16,33 @@
 
 YearModel::YearModel(QObject *parent)
     : QAbstractListModel(parent)
-    , m_from(1, 1, 1)
-    , m_to(275759, 9, 25)
+    , m_from(QDate(1, 1, 1))
+    , m_to(QDate(275759, 9, 25))
 {
 }
 
-QDate YearModel::from() const
+QDateTime YearModel::from() const
 {
-    return m_from;
+    return QDateTime(m_from.date());
 }
 
-void YearModel::setFrom(const QDate &date)
+void YearModel::setFrom(const QDateTime &date)
 {
-    if (m_from == date)
+    if (m_from.date() == date.date())
         return;
 
     m_from = date;
     Q_EMIT fromChanged();
 }
 
-QDate YearModel::to() const
+QDateTime YearModel::to() const
 {
     return m_to;
 }
 
-void YearModel::setTo(const QDate &date)
+void YearModel::setTo(const QDateTime &date)
 {
-    if (m_to == date)
+    if (m_to.date() == date.date())
         return;
 
     m_to = date;
@@ -86,7 +86,7 @@ void YearModel::reset()
     m_list.clear();
 
     if (m_from < m_to) {
-        for (int i = m_from.year(); i < m_to.year(); i++)
+        for (int i = m_from.date().year(); i < m_to.date().year(); i++)
             m_list.append(i);
     }
 

--- a/src/imports/templates/yearmodel.h
+++ b/src/imports/templates/yearmodel.h
@@ -22,18 +22,18 @@
 class YearModel : public QAbstractListModel
 {
     Q_OBJECT
-    Q_PROPERTY(QDate from READ from WRITE setFrom NOTIFY fromChanged FINAL)
-    Q_PROPERTY(QDate to READ to WRITE setTo NOTIFY toChanged FINAL)
+    Q_PROPERTY(QDateTime from READ from WRITE setFrom NOTIFY fromChanged FINAL)
+    Q_PROPERTY(QDateTime to READ to WRITE setTo NOTIFY toChanged FINAL)
     Q_PROPERTY(int count READ rowCount NOTIFY countChanged FINAL)
     Q_DISABLE_COPY(YearModel)
 public:
     explicit YearModel(QObject *parent = nullptr);
 
-    QDate from() const;
-    void setFrom(const QDate &date);
+    QDateTime from() const;
+    void setFrom(const QDateTime &date);
 
-    QDate to() const;
-    void setTo(const QDate &date);
+    QDateTime to() const;
+    void setTo(const QDateTime &date);
 
     QHash<int, QByteArray> roleNames() const override;
     QVariant data(const QModelIndex &index, int role) const override;
@@ -49,8 +49,8 @@ Q_SIGNALS:
     void countChanged();
 
 private:
-    QDate m_from;
-    QDate m_to;
+    QDateTime m_from;
+    QDateTime m_to;
     QVector<int> m_list;
 };
 

--- a/src/imports/templates/yearselector.cpp
+++ b/src/imports/templates/yearselector.cpp
@@ -18,8 +18,8 @@
 YearSelector::YearSelector(QQuickItem *parent)
     : QQuickItem(parent)
     , m_model(new YearModel(this))
-    , m_from(1, 1, 1)
-    , m_to(275759, 9, 25)
+    , m_from(QDate(1, 1, 1))
+    , m_to(QDate(275759, 9, 25))
     , m_selectedYear(QDate::currentDate().year())
 {
     m_model->setFrom(m_from);
@@ -88,14 +88,14 @@ void YearSelector::resetVisibleItemCount()
     setVisibleItemCount(7);
 }
 
-QDate YearSelector::from() const
+QDateTime YearSelector::from() const
 {
     return m_from;
 }
 
-void YearSelector::setFrom(const QDate &date)
+void YearSelector::setFrom(const QDateTime &date)
 {
-    if (m_from == date)
+    if (m_from.date() == date.date())
         return;
 
     m_from = date;
@@ -109,17 +109,17 @@ void YearSelector::setFrom(const QDate &date)
 
 void YearSelector::resetFrom()
 {
-    setFrom(QDate(1, 1, 1));
+    setFrom(QDateTime(QDate(1, 1, 1)));
 }
 
-QDate YearSelector::to() const
+QDateTime YearSelector::to() const
 {
-    return m_to;
+    return QDateTime(m_to.date());
 }
 
-void YearSelector::setTo(const QDate &date)
+void YearSelector::setTo(const QDateTime &date)
 {
-    if (m_to == date)
+    if (m_to.date() == date.date())
         return;
 
     m_to = date;
@@ -133,7 +133,7 @@ void YearSelector::setTo(const QDate &date)
 
 void YearSelector::resetTo()
 {
-    setTo(QDate(275759, 9, 25));
+    setTo(QDateTime(QDate(275759, 9, 25)));
 }
 
 int YearSelector::selectedYear() const

--- a/src/imports/templates/yearselector.h
+++ b/src/imports/templates/yearselector.h
@@ -28,8 +28,8 @@ class YearSelector : public QQuickItem
     Q_PROPERTY(QQuickItem *contentItem READ contentItem WRITE setContentItem NOTIFY contentItemChanged FINAL)
     Q_PROPERTY(QQmlComponent *delegate READ delegate WRITE setDelegate NOTIFY delegateChanged FINAL)
     Q_PROPERTY(int visibleItemCount READ visibleItemCount WRITE setVisibleItemCount RESET resetVisibleItemCount NOTIFY visibleItemCountChanged FINAL)
-    Q_PROPERTY(QDate from READ from WRITE setFrom RESET resetFrom NOTIFY fromChanged FINAL)
-    Q_PROPERTY(QDate to READ to WRITE setTo RESET resetTo NOTIFY toChanged FINAL)
+    Q_PROPERTY(QDateTime from READ from WRITE setFrom RESET resetFrom NOTIFY fromChanged FINAL)
+    Q_PROPERTY(QDateTime to READ to WRITE setTo RESET resetTo NOTIFY toChanged FINAL)
     Q_PROPERTY(int selectedYear READ selectedYear WRITE setSelectedYear NOTIFY selectedYearChanged FINAL)
     Q_DISABLE_COPY(YearSelector)
 public:
@@ -49,12 +49,12 @@ public:
     void setVisibleItemCount(int visibleItemCount);
     void resetVisibleItemCount();
 
-    QDate from() const;
-    void setFrom(const QDate &date);
+    QDateTime from() const;
+    void setFrom(const QDateTime &date);
     void resetFrom();
 
-    QDate to() const;
-    void setTo(const QDate &date);
+    QDateTime to() const;
+    void setTo(const QDateTime &date);
     void resetTo();
 
     int selectedYear() const;
@@ -72,8 +72,8 @@ Q_SIGNALS:
 
 private:
     YearModel *m_model = nullptr;
-    QDate m_from;
-    QDate m_to;
+    QDateTime m_from;
+    QDateTime m_to;
     QQuickItem *m_contentItem = nullptr;
     QQmlComponent *m_delegate = nullptr;
     int m_visibleItemCount = 7;


### PR DESCRIPTION
- This change fixes the crash of the DatetimePicker on instantiation. It seems to be an issue with the implicit conversion of a ```QDate``` to a QML ```date``` object.
- Fix date colors when in Dark mode (not enough contrast previously)